### PR TITLE
Update Minecraft wiki links to new domain

### DIFF
--- a/10/advancements.hjson
+++ b/10/advancements.hjson
@@ -289,7 +289,7 @@
                                             props: {
                                                 potion: {
                                                     desc: A brewed potion ID.
-                                                    href: https://minecraft.fandom.com/wiki/Potion#Item_data
+                                                    href: https://minecraft.wiki/w/Potion#Item_data
                                                     type: string
                                                     allow: *a-z0-9_\/:.-
                                                 }
@@ -462,7 +462,7 @@
                                             props: {
                                                 block: {
                                                     desc: The block that the player is standing in. Accepts block IDs
-                                                    href: https://minecraft.fandom.com/wiki/Java_Edition_data_values/Blocks
+                                                    href: https://minecraft.wiki/w/Java_Edition_data_values/Blocks
                                                     type: string
                                                     allow: *a-z0-9_\/:.-
                                                 }

--- a/10/item_modifiers.hjson
+++ b/10/item_modifiers.hjson
@@ -100,7 +100,7 @@
                                         props: {
                                             id: {
                                                 desc: The namespaced item ID.
-                                                href: https://minecraft.fandom.com/wiki/Java_Edition_data_values#Blocks
+                                                href: https://minecraft.wiki/w/Java_Edition_data_values#Blocks
                                                 type: string
                                                 allow: *a-z0-9_#\/:.-
                                             }
@@ -133,7 +133,7 @@
                                             }
                                             type: {
                                                 desc: A string containing the type of the entity. Should be a namespaced entity ID. Present minecraft:pig if invalid.
-                                                href: https://minecraft.fandom.com/wiki/Java_Edition_data_values/Entities
+                                                href: https://minecraft.wiki/w/Java_Edition_data_values/Entities
                                                 type: string
                                                 allow: *a-z0-9_#\/:.-
                                             }
@@ -203,7 +203,7 @@
                 {title: "key", type: "object", extend: "jsontxtbase", props: {
                     keybind: {
                         desc: A keybind identifier, to be displayed as the name of the button that is currently bound to that action. For example, {"keybind": "key.inventory"} displays "e" if the player is using the default control scheme.
-                        href: https://minecraft.fandom.com/wiki/Controls#Configurable_controls
+                        href: https://minecraft.wiki/w/Controls#Configurable_controls
                         type: string
                     }
                 }}
@@ -284,7 +284,7 @@
                         "string-minecraft:apply_bonus": {
                             enchantment: {
                                 desc: Enchantment ID used for level calculation.
-                                href: https://minecraft.fandom.com/wiki/Java_Edition_data_value#Enchantments
+                                href: https://minecraft.wiki/w/Java_Edition_data_value#Enchantments
                                 type: string
                                 allow: *a-z0-9_#\/:.-
                             }
@@ -367,7 +367,7 @@
                         "string-minecraft:copy_state": {
                             block: {
                                 desc: A block ID. Function fails if the block doesn't match.
-                                href: https://minecraft.fandom.com/wiki/Resource_location
+                                href: https://minecraft.wiki/w/Resource_location
                                 type: string
                             }
                             properties: {
@@ -379,7 +379,7 @@
                         "string-minecraft:enchant_randomly": {
                             enchantments: {
                                 desc: A list of enchantment IDs to choose from to enchant the item with. Only one will be selected, just with a random level. If omitted, all enchantments applicable to the item are possible.
-                                href: https://minecraft.fandom.com/wiki/Java_Edition_data_value#Enchantments
+                                href: https://minecraft.wiki/w/Java_Edition_data_value#Enchantments
                                 type: list
                                 vals: {type: "string"}
                             }
@@ -391,13 +391,13 @@
                         "string-minecraft:exploration_map": {
                             destination: {
                                 desc: The type of generated structure to convert this empty map to lead to. Accepts any structure id used by the /locate command.
-                                href: https://minecraft.fandom.com/wiki/Commands/locate#Arguments
+                                href: https://minecraft.wiki/w/Commands/locate#Arguments
                                 type: string
                                 allow: *a-z0-9_#\/:.-
                             }
                             decoration: {
                                 desc: The icon used to mark the destination on the map. Accepts any of the map icon text IDs (case insensitive). If mansion or monument is used, the color of the lines on the item texture changes to match the corresponding explorer map.
-                                href: https://minecraft.fandom.com/wiki/Map#Map_icons
+                                href: https://minecraft.wiki/w/Map#Map_icons
                                 type: string
                                 allow: *a-z0-9_#\/:.-
                             }
@@ -492,7 +492,7 @@
                                     props: {
                                         pattern: {
                                             desc: The pattern type. For example square_bottom_left.
-                                            href: https://minecraft.fandom.com/wiki/Banner/Patterns
+                                            href: https://minecraft.wiki/w/Banner/Patterns
                                             type: string
                                             allow: *a-z0-9_#\/:.-
                                         }
@@ -607,7 +607,7 @@
                         "string-minecraft:set_potion": {
                             id: {
                                 desc: The potion ID.
-                                href: https://minecraft.fandom.com/wiki/Potion#Java_Edition
+                                href: https://minecraft.wiki/w/Potion#Java_Edition
                                 type: string
                                 allow: *a-z0-9_#\/:.-
                             }
@@ -621,7 +621,7 @@
                                     props: {
                                         type: {
                                             desc: The effect ID.
-                                            href: https://minecraft.fandom.com/wiki/Effect#Effect_list
+                                            href: https://minecraft.wiki/w/Effect#Effect_list
                                             type: string
                                             allow: *a-z0-9_#\/:.-
                                         }

--- a/10/loot_tables.hjson
+++ b/10/loot_tables.hjson
@@ -49,7 +49,7 @@
                         "string-minecraft:item": {
                             name: {
                                 desc: ID name of the item to be produced, e.g. diamond. The default, if not changed by functions, is a stack of 1 of the default instance of the item.
-                                href: https://minecraft.fandom.com/wiki/Java_Edition_data_values#Blocks
+                                href: https://minecraft.wiki/w/Java_Edition_data_values#Blocks
                                 type: string
                                 allow: *a-z0-9_#\/:.-
                             }

--- a/10/meta.hjson
+++ b/10/meta.hjson
@@ -31,7 +31,7 @@
                 10: 1.19.0 - 1.19.3
                 12: 1.19.4
                 '''
-            href: https://minecraft.fandom.com/wiki/Pack_format
+            href: https://minecraft.wiki/w/Pack_format
             type: integer
             min: 1
             max: 15

--- a/10/powers.hjson
+++ b/10/powers.hjson
@@ -274,7 +274,7 @@
                                 "string-origins:attribute": {
                                     attribute: {
                                         desc: ID of the attribute of which the value should be checked.
-                                        href: https://minecraft.fandom.com/wiki/Attribute
+                                        href: https://minecraft.wiki/w/Attribute
                                         type: string
                                         allow: *a-z0-9_#\/:.-
                                     }
@@ -290,13 +290,13 @@
                                 "string-origins:biome": {
                                     biome: {
                                         desc: If set, this is the ID of the biome the player needs to be in for this condition to evaluate to true, e.g. minecraft:savanna.
-                                        href: https://minecraft.fandom.com/wiki/Biome#Biome_IDs
+                                        href: https://minecraft.wiki/w/Biome#Biome_IDs
                                         type: string
                                         allow: *a-z0-9_#\/:.-
                                     }
                                     biomes: {
                                         desc: If set, these are the allowed biome IDs the player can be in for this condition to evaluate to true.
-                                        href: https://minecraft.fandom.com/wiki/Biome#Biome_IDs
+                                        href: https://minecraft.wiki/w/Biome#Biome_IDs
                                         type: list
                                         vals: {
                                             type: string
@@ -465,7 +465,7 @@
                                 "string-origins:entity_group": {
                                     group: {
                                         desc: Entity group required for the entity to pass the check. One of default, undead, arthropod, illager, or aquatic. Click for more information about the entity groups.
-                                        href: https://minecraft.fandom.com/wiki/Mob#Classification
+                                        href: https://minecraft.wiki/w/Mob#Classification
                                         enum: ["default", "undead", "arthropod", "illager", "aquatic"]
                                     }
                                 }
@@ -992,7 +992,7 @@
                                 "string-origins:harvest_level": {
                                     comparison: {
                                         desc: How the item's harvest level should be compared to the specified value. Click to visit the wiki to learn more about harvest levels.
-                                        href: https://minecraft.fandom.com/wiki/Tiers
+                                        href: https://minecraft.wiki/w/Tiers
                                         link: comparison
                                     }
                                     compare_to: {
@@ -1124,7 +1124,7 @@
                                 "string-origins:block": {
                                     block: {
                                         desc: ID of the block that this block needs to be to pass the check.
-                                        href: https://minecraft.fandom.com/wiki/Java_Edition_data_values/Blocks
+                                        href: https://minecraft.wiki/w/Java_Edition_data_values/Blocks
                                         type: string
                                         allow: *a-z0-9_\/:.-
                                     }
@@ -2060,7 +2060,7 @@
                                 "string-origins:emit_game_event": {
                                     event: {
                                         desc: The ID of a game event to emit. Click to see vanilla game events.
-                                        href: https://minecraft.fandom.com/wiki/Sculk_Sensor#Vibration_amplitudes
+                                        href: https://minecraft.wiki/w/Sculk_Sensor#Vibration_amplitudes
                                         type: string
                                         allow: *a-z0-9_#\/:.-
                                     }
@@ -2218,7 +2218,7 @@
                                     stat: {
                                         desc: The statistic to modify.
                                         type: string
-                                        href: https://minecraft.fandom.com/wiki/Statistics#Resource_location
+                                        href: https://minecraft.wiki/w/Statistics#Resource_location
                                     }
                                     modifier: {
                                         desc: The modifier to apply to the given stat.
@@ -3160,7 +3160,7 @@
                         "string-origins:attribute_modify_transfer": {
                             attribute: {
                                 desc: The namespace and ID of the attribute to transfer the value from.
-                                href: https://minecraft.fandom.com/wiki/Attribute
+                                href: https://minecraft.wiki/w/Attribute
                                 type: string
                             }
                             class: {
@@ -3368,7 +3368,7 @@
                         "string-origins:entity_group": {
                             group: {
                                 desc: The group to associate with the player. One of default, undead, arthropod, illager, or aquatic. Click for more information about the entity groups.
-                                href: https://minecraft.fandom.com/wiki/Mob#Classification
+                                href: https://minecraft.wiki/w/Mob#Classification
                                 enum: ["default", "undead", "arthropod", "illager", "aquatic"]
                             }
                         }
@@ -4367,7 +4367,7 @@
                         "string-origins:modify_attribute": {
                             attribute: {
                                 desc: ID of the attribute of which the modifier should be applied.
-                                href: https://minecraft.fandom.com/wiki/Attribute
+                                href: https://minecraft.wiki/w/Attribute
                                 type: string
                                 allow: *a-z0-9_#\/:.-
                             }
@@ -4717,13 +4717,13 @@
                             }
                             biome: {
                                 desc: If set, the player will spawn in the biome with this ID.
-                                href: https://minecraft.fandom.com/wiki/Biome#Biome_IDs
+                                href: https://minecraft.wiki/w/Biome#Biome_IDs
                                 type: string
                                 allow: *a-z0-9_#\/:.-
                             }
                             structure: {
                                 desc: ID of the structure the player should spawn in. Keep in mind that the structure needs to generate in the specified dimension!
-                                href: https://minecraft.fandom.com/wiki/Commands/locate#Arguments
+                                href: https://minecraft.wiki/w/Commands/locate#Arguments
                                 type: string
                                 allow: *a-z0-9_#\/:.-
                             }
@@ -5231,7 +5231,7 @@
             props: {
                 attribute: {
                     desc: ID of the attribute which will be modified by this modifier.
-                    href: https://minecraft.fandom.com/wiki/Attribute
+                    href: https://minecraft.wiki/w/Attribute
                     type: string
                     allow: *a-z0-9_#\/:.-
                 }

--- a/10/predicates.hjson
+++ b/10/predicates.hjson
@@ -60,7 +60,7 @@
             props: {
                 biome: {
                     desc: The biome at the given location.
-                    href: https://minecraft.fandom.com/wiki/Biome#Biome_IDs
+                    href: https://minecraft.wiki/w/Biome#Biome_IDs
                     type: string
                     allow: *a-z0-9#\/:.-
                 }
@@ -69,7 +69,7 @@
                     props: {
                         blocks: {
                             desc: A list of block IDs.
-                            href: https://minecraft.fandom.com/wiki/Java_Edition_data_values/Blocks
+                            href: https://minecraft.wiki/w/Java_Edition_data_values/Blocks
                             type: list
                             vals: {link: "block"}
                         }
@@ -102,7 +102,7 @@
                     props: {
                         blocks: {
                             desc: The fluid ID.
-                            href: https://minecraft.fandom.com/wiki/Java_Edition_data_values#Fluids
+                            href: https://minecraft.wiki/w/Java_Edition_data_values#Fluids
                             type: string
                             allow: *a-z0-9#\/:.-
                         }
@@ -137,7 +137,7 @@
                 }
                 feature: {
                     desc: Whether or not this location is inside a naturally generating structure.
-                    href: https://minecraft.fandom.com/wiki/Commands/locate#Arguments
+                    href: https://minecraft.wiki/w/Commands/locate#Arguments
                     type: string
                 }
                 light: {
@@ -178,7 +178,7 @@
                 }
                 effects: {
                     desc: A list of status effects. The key name is the status effect id.
-                    href: https://minecraft.fandom.com/wiki/Java_Edition_data_values/Effects
+                    href: https://minecraft.wiki/w/Java_Edition_data_values/Effects
                     type: object
                     extra: {
                         type: object
@@ -325,7 +325,7 @@
                 }
                 type: {
                     desc: An entity ID.
-                    href: https://minecraft.fandom.com/wiki/Data_values/Entity_IDs
+                    href: https://minecraft.wiki/w/Data_values/Entity_IDs
                     type: string
                     allow: *a-z0-9_#\/:.-
                 }
@@ -336,7 +336,7 @@
             props: {
                 items: {
                     desc: A list of item IDs.
-                    href: https://minecraft.fandom.com/wiki/Java_Edition_data_values#Blocks
+                    href: https://minecraft.wiki/w/Java_Edition_data_values#Blocks
                     type: list
                     vals: {link: "item"}
                 }
@@ -360,7 +360,7 @@
                 }
                 potion: {
                     desc: A brewed potion ID.
-                    href: https://minecraft.fandom.com/wiki/Potion#Item_data
+                    href: https://minecraft.wiki/w/Potion#Item_data
                     type: string
                     allow: *a-z0-9_#\/:.-
                 }
@@ -372,7 +372,7 @@
                         props: {
                             enchantment: {
                                 desc: An enchantment ID.
-                                href: https://minecraft.fandom.com/wiki/Java_Edition_data_values#Enchantments
+                                href: https://minecraft.wiki/w/Java_Edition_data_values#Enchantments
                                 type: string
                                 allow: *a-z0-9_#\/:.-
                             }
@@ -391,7 +391,7 @@
                         props: {
                             enchantment: {
                                 desc: An enchantment ID.
-                                href: https://minecraft.fandom.com/wiki/Java_Edition_data_values#Enchantments
+                                href: https://minecraft.wiki/w/Java_Edition_data_values#Enchantments
                                 type: string
                                 allow: *a-z0-9_#\/:.-
                             }
@@ -622,13 +622,13 @@
         }
         item: {
             desc: A Minecraft item (or block item), vanilla or modded.
-            href: https://minecraft.fandom.com/wiki/Java_Edition_data_values#Blocks
+            href: https://minecraft.wiki/w/Java_Edition_data_values#Blocks
             type: string
             allow: *a-z0-9_#\/:.-
         }
         block: {
             desc: A Minecraft block, vanilla or modded.
-            href: https://minecraft.fandom.com/wiki/Java_Edition_data_values/Blocks
+            href: https://minecraft.wiki/w/Java_Edition_data_values/Blocks
             type: string
             allow: *a-z0-9_#\/:.-
         }

--- a/12/advancements.hjson
+++ b/12/advancements.hjson
@@ -290,7 +290,7 @@
                                             props: {
                                                 potion: {
                                                     desc: A brewed potion ID.
-                                                    href: https://minecraft.fandom.com/wiki/Potion#Item_data
+                                                    href: https://minecraft.wiki/w/Potion#Item_data
                                                     type: string
                                                     allow: *a-z0-9_\/:.-
                                                 }
@@ -463,7 +463,7 @@
                                             props: {
                                                 block: {
                                                     desc: The block that the player is standing in. Accepts block IDs
-                                                    href: https://minecraft.fandom.com/wiki/Java_Edition_data_values/Blocks
+                                                    href: https://minecraft.wiki/w/Java_Edition_data_values/Blocks
                                                     type: string
                                                     allow: *a-z0-9_\/:.-
                                                 }

--- a/12/damage_type.hjson
+++ b/12/damage_type.hjson
@@ -15,12 +15,12 @@
             enum: ["never", "when_caused_by_living_non_player", "always"]
         }
         effects: {
-            href: https://minecraft.fandom.com/wiki/Damage_type#Effects
+            href: https://minecraft.wiki/w/Damage_type#Effects
             desc: Optional field controlling how incoming damage is shown to the player.
             enum: ["hurt", "thorns", "drowning", "burning", "poking", "freezing"]
         }
         death_message_type: {
-            href: https://minecraft.fandom.com/wiki/Damage_type#Death_messages
+            href: https://minecraft.wiki/w/Damage_type#Death_messages
             desc: Optional field that controls the kind of death messages to use.
             enum: ["default", "fall_variants", "intentional_game_design"]
         }

--- a/12/item_modifiers.hjson
+++ b/12/item_modifiers.hjson
@@ -100,7 +100,7 @@
                                         props: {
                                             id: {
                                                 desc: The namespaced item ID.
-                                                href: https://minecraft.fandom.com/wiki/Java_Edition_data_values#Blocks
+                                                href: https://minecraft.wiki/w/Java_Edition_data_values#Blocks
                                                 type: string
                                                 allow: *a-z0-9_#\/:.-
                                             }
@@ -133,7 +133,7 @@
                                             }
                                             type: {
                                                 desc: A string containing the type of the entity. Should be a namespaced entity ID. Present minecraft:pig if invalid.
-                                                href: https://minecraft.fandom.com/wiki/Java_Edition_data_values/Entities
+                                                href: https://minecraft.wiki/w/Java_Edition_data_values/Entities
                                                 type: string
                                                 allow: *a-z0-9_#\/:.-
                                             }
@@ -203,7 +203,7 @@
                 {title: "key", type: "object", extend: "jsontxtbase", props: {
                     keybind: {
                         desc: A keybind identifier, to be displayed as the name of the button that is currently bound to that action. For example, {"keybind": "key.inventory"} displays "e" if the player is using the default control scheme.
-                        href: https://minecraft.fandom.com/wiki/Controls#Configurable_controls
+                        href: https://minecraft.wiki/w/Controls#Configurable_controls
                         type: string
                     }
                 }}
@@ -284,7 +284,7 @@
                         "string-minecraft:apply_bonus": {
                             enchantment: {
                                 desc: Enchantment ID used for level calculation.
-                                href: https://minecraft.fandom.com/wiki/Java_Edition_data_value#Enchantments
+                                href: https://minecraft.wiki/w/Java_Edition_data_value#Enchantments
                                 type: string
                                 allow: *a-z0-9_#\/:.-
                             }
@@ -367,7 +367,7 @@
                         "string-minecraft:copy_state": {
                             block: {
                                 desc: A block ID. Function fails if the block doesn't match.
-                                href: https://minecraft.fandom.com/wiki/Resource_location
+                                href: https://minecraft.wiki/w/Resource_location
                                 type: string
                             }
                             properties: {
@@ -379,7 +379,7 @@
                         "string-minecraft:enchant_randomly": {
                             enchantments: {
                                 desc: A list of enchantment IDs to choose from to enchant the item with. Only one will be selected, just with a random level. If omitted, all enchantments applicable to the item are possible.
-                                href: https://minecraft.fandom.com/wiki/Java_Edition_data_value#Enchantments
+                                href: https://minecraft.wiki/w/Java_Edition_data_value#Enchantments
                                 type: list
                                 vals: {type: "string"}
                             }
@@ -391,13 +391,13 @@
                         "string-minecraft:exploration_map": {
                             destination: {
                                 desc: The type of generated structure to convert this empty map to lead to. Accepts any structure id used by the /locate command.
-                                href: https://minecraft.fandom.com/wiki/Commands/locate#Arguments
+                                href: https://minecraft.wiki/w/Commands/locate#Arguments
                                 type: string
                                 allow: *a-z0-9_#\/:.-
                             }
                             decoration: {
                                 desc: The icon used to mark the destination on the map. Accepts any of the map icon text IDs (case insensitive). If mansion or monument is used, the color of the lines on the item texture changes to match the corresponding explorer map.
-                                href: https://minecraft.fandom.com/wiki/Map#Map_icons
+                                href: https://minecraft.wiki/w/Map#Map_icons
                                 type: string
                                 allow: *a-z0-9_#\/:.-
                             }
@@ -492,7 +492,7 @@
                                     props: {
                                         pattern: {
                                             desc: The pattern type. For example square_bottom_left.
-                                            href: https://minecraft.fandom.com/wiki/Banner/Patterns
+                                            href: https://minecraft.wiki/w/Banner/Patterns
                                             type: string
                                             allow: *a-z0-9_#\/:.-
                                         }
@@ -607,7 +607,7 @@
                         "string-minecraft:set_potion": {
                             id: {
                                 desc: The potion ID.
-                                href: https://minecraft.fandom.com/wiki/Potion#Java_Edition
+                                href: https://minecraft.wiki/w/Potion#Java_Edition
                                 type: string
                                 allow: *a-z0-9_#\/:.-
                             }
@@ -621,7 +621,7 @@
                                     props: {
                                         type: {
                                             desc: The effect ID.
-                                            href: https://minecraft.fandom.com/wiki/Effect#Effect_list
+                                            href: https://minecraft.wiki/w/Effect#Effect_list
                                             type: string
                                             allow: *a-z0-9_#\/:.-
                                         }

--- a/12/loot_tables.hjson
+++ b/12/loot_tables.hjson
@@ -49,7 +49,7 @@
                         "string-minecraft:item": {
                             name: {
                                 desc: ID name of the item to be produced, e.g. diamond. The default, if not changed by functions, is a stack of 1 of the default instance of the item.
-                                href: https://minecraft.fandom.com/wiki/Java_Edition_data_values#Blocks
+                                href: https://minecraft.wiki/w/Java_Edition_data_values#Blocks
                                 type: string
                                 allow: *a-z0-9_#\/:.-
                             }

--- a/12/powers.hjson
+++ b/12/powers.hjson
@@ -275,7 +275,7 @@
                                 "string-origins:attribute": {
                                     attribute: {
                                         desc: ID of the attribute of which the value should be checked.
-                                        href: https://minecraft.fandom.com/wiki/Attribute
+                                        href: https://minecraft.wiki/w/Attribute
                                         type: string
                                         allow: *a-z0-9_#\/:.-
                                     }
@@ -291,13 +291,13 @@
                                 "string-origins:biome": {
                                     biome: {
                                         desc: If set, this is the ID of the biome the player needs to be in for this condition to evaluate to true, e.g. minecraft:savanna.
-                                        href: https://minecraft.fandom.com/wiki/Biome#Biome_IDs
+                                        href: https://minecraft.wiki/w/Biome#Biome_IDs
                                         type: string
                                         allow: *a-z0-9_#\/:.-
                                     }
                                     biomes: {
                                         desc: If set, these are the allowed biome IDs the player can be in for this condition to evaluate to true.
-                                        href: https://minecraft.fandom.com/wiki/Biome#Biome_IDs
+                                        href: https://minecraft.wiki/w/Biome#Biome_IDs
                                         type: list
                                         vals: {
                                             type: string
@@ -470,7 +470,7 @@
                                 "string-origins:entity_group": {
                                     group: {
                                         desc: Entity group required for the entity to pass the check. One of default, undead, arthropod, illager, or aquatic. Click for more information about the entity groups.
-                                        href: https://minecraft.fandom.com/wiki/Mob#Classification
+                                        href: https://minecraft.wiki/w/Mob#Classification
                                         enum: ["default", "undead", "arthropod", "illager", "aquatic"]
                                     }
                                 }
@@ -998,7 +998,7 @@
                                 "string-origins:harvest_level": {
                                     comparison: {
                                         desc: How the item's harvest level should be compared to the specified value. Click to visit the wiki to learn more about harvest levels.
-                                        href: https://minecraft.fandom.com/wiki/Tiers
+                                        href: https://minecraft.wiki/w/Tiers
                                         link: comparison
                                     }
                                     compare_to: {
@@ -1130,7 +1130,7 @@
                                 "string-origins:block": {
                                     block: {
                                         desc: ID of the block that this block needs to be to pass the check.
-                                        href: https://minecraft.fandom.com/wiki/Java_Edition_data_values/Blocks
+                                        href: https://minecraft.wiki/w/Java_Edition_data_values/Blocks
                                         type: string
                                         allow: *a-z0-9_\/:.-
                                     }
@@ -1531,7 +1531,7 @@
                                 "string-origins:from_falling": {}
                                 "string-origins:in_tag": {
                                     tag: {
-                                        href: https://minecraft.fandom.com/wiki/Tag#Damage_types
+                                        href: https://minecraft.wiki/w/Tag#Damage_types
                                         desc: The namespace and ID of the tag which the damage type should be in to pass the check.
                                         type: string
                                         allow: *a-z0-9_#\/:.-
@@ -2096,7 +2096,7 @@
                                 "string-origins:emit_game_event": {
                                     event: {
                                         desc: The ID of a game event to emit. Click to see vanilla game events.
-                                        href: https://minecraft.fandom.com/wiki/Sculk_Sensor#Vibration_amplitudes
+                                        href: https://minecraft.wiki/w/Sculk_Sensor#Vibration_amplitudes
                                         type: string
                                         allow: *a-z0-9_#\/:.-
                                     }
@@ -2261,7 +2261,7 @@
                                     stat: {
                                         desc: The statistic to modify.
                                         type: string
-                                        href: https://minecraft.fandom.com/wiki/Statistics#Resource_location
+                                        href: https://minecraft.wiki/w/Statistics#Resource_location
                                     }
                                     modifier: {
                                         desc: The modifier to apply to the given stat.
@@ -2472,7 +2472,7 @@
                                 }
                                 "string-origins:selector_action": {
                                     selector: {
-                                        href: https://minecraft.fandom.com/wiki/Target_selectors
+                                        href: https://minecraft.wiki/w/Target_selectors
                                         desc: The selector to use for selecting entities. It can be the username of a player, the UUID of the entity or a target selector.
                                         type: string
                                         ext: true
@@ -3251,7 +3251,7 @@
                         "string-origins:attribute_modify_transfer": {
                             attribute: {
                                 desc: The namespace and ID of the attribute to transfer the value from.
-                                href: https://minecraft.fandom.com/wiki/Attribute
+                                href: https://minecraft.wiki/w/Attribute
                                 type: string
                             }
                             class: {
@@ -3464,7 +3464,7 @@
                         "string-origins:entity_group": {
                             group: {
                                 desc: The group to associate with the player. One of default, undead, arthropod, illager, or aquatic. Click for more information about the entity groups.
-                                href: https://minecraft.fandom.com/wiki/Mob#Classification
+                                href: https://minecraft.wiki/w/Mob#Classification
                                 enum: ["default", "undead", "arthropod", "illager", "aquatic"]
                             }
                         }
@@ -4514,7 +4514,7 @@
                         "string-origins:modify_attribute": {
                             attribute: {
                                 desc: ID of the attribute of which the modifier should be applied.
-                                href: https://minecraft.fandom.com/wiki/Attribute
+                                href: https://minecraft.wiki/w/Attribute
                                 type: string
                                 allow: *a-z0-9_#\/:.-
                             }
@@ -4864,13 +4864,13 @@
                             }
                             biome: {
                                 desc: If set, the player will spawn in the biome with this ID.
-                                href: https://minecraft.fandom.com/wiki/Biome#Biome_IDs
+                                href: https://minecraft.wiki/w/Biome#Biome_IDs
                                 type: string
                                 allow: *a-z0-9_#\/:.-
                             }
                             structure: {
                                 desc: ID of the structure the player should spawn in. Keep in mind that the structure needs to generate in the specified dimension!
-                                href: https://minecraft.fandom.com/wiki/Commands/locate#Arguments
+                                href: https://minecraft.wiki/w/Commands/locate#Arguments
                                 type: string
                                 allow: *a-z0-9_#\/:.-
                             }
@@ -5378,7 +5378,7 @@
             props: {
                 attribute: {
                     desc: ID of the attribute which will be modified by this modifier.
-                    href: https://minecraft.fandom.com/wiki/Attribute
+                    href: https://minecraft.wiki/w/Attribute
                     type: string
                     allow: *a-z0-9_#\/:.-
                 }

--- a/12/predicates.hjson
+++ b/12/predicates.hjson
@@ -38,7 +38,7 @@
             props: {
                 biome: {
                     desc: The biome at the given location.
-                    href: https://minecraft.fandom.com/wiki/Biome#Biome_IDs
+                    href: https://minecraft.wiki/w/Biome#Biome_IDs
                     type: string
                     allow: *a-z0-9#\/:.-
                 }
@@ -47,7 +47,7 @@
                     props: {
                         blocks: {
                             desc: A list of block IDs.
-                            href: https://minecraft.fandom.com/wiki/Java_Edition_data_values/Blocks
+                            href: https://minecraft.wiki/w/Java_Edition_data_values/Blocks
                             type: list
                             vals: {link: "block"}
                         }
@@ -80,7 +80,7 @@
                     props: {
                         blocks: {
                             desc: The fluid ID.
-                            href: https://minecraft.fandom.com/wiki/Java_Edition_data_values#Fluids
+                            href: https://minecraft.wiki/w/Java_Edition_data_values#Fluids
                             type: string
                             allow: *a-z0-9#\/:.-
                         }
@@ -115,7 +115,7 @@
                 }
                 feature: {
                     desc: Whether or not this location is inside a naturally generating structure.
-                    href: https://minecraft.fandom.com/wiki/Commands/locate#Arguments
+                    href: https://minecraft.wiki/w/Commands/locate#Arguments
                     type: string
                 }
                 light: {
@@ -156,7 +156,7 @@
                 }
                 effects: {
                     desc: A list of status effects. The key name is the status effect id.
-                    href: https://minecraft.fandom.com/wiki/Java_Edition_data_values/Effects
+                    href: https://minecraft.wiki/w/Java_Edition_data_values/Effects
                     type: object
                     extra: {
                         type: object
@@ -303,7 +303,7 @@
                 }
                 type: {
                     desc: An entity ID.
-                    href: https://minecraft.fandom.com/wiki/Data_values/Entity_IDs
+                    href: https://minecraft.wiki/w/Data_values/Entity_IDs
                     type: string
                     allow: *a-z0-9_#\/:.-
                 }
@@ -314,7 +314,7 @@
             props: {
                 items: {
                     desc: A list of item IDs.
-                    href: https://minecraft.fandom.com/wiki/Java_Edition_data_values#Blocks
+                    href: https://minecraft.wiki/w/Java_Edition_data_values#Blocks
                     type: list
                     vals: {link: "item"}
                 }
@@ -338,7 +338,7 @@
                 }
                 potion: {
                     desc: A brewed potion ID.
-                    href: https://minecraft.fandom.com/wiki/Potion#Item_data
+                    href: https://minecraft.wiki/w/Potion#Item_data
                     type: string
                     allow: *a-z0-9_#\/:.-
                 }
@@ -350,7 +350,7 @@
                         props: {
                             enchantment: {
                                 desc: An enchantment ID.
-                                href: https://minecraft.fandom.com/wiki/Java_Edition_data_values#Enchantments
+                                href: https://minecraft.wiki/w/Java_Edition_data_values#Enchantments
                                 type: string
                                 allow: *a-z0-9_#\/:.-
                             }
@@ -369,7 +369,7 @@
                         props: {
                             enchantment: {
                                 desc: An enchantment ID.
-                                href: https://minecraft.fandom.com/wiki/Java_Edition_data_values#Enchantments
+                                href: https://minecraft.wiki/w/Java_Edition_data_values#Enchantments
                                 type: string
                                 allow: *a-z0-9_#\/:.-
                             }
@@ -600,13 +600,13 @@
         }
         item: {
             desc: A Minecraft item (or block item), vanilla or modded.
-            href: https://minecraft.fandom.com/wiki/Java_Edition_data_values#Blocks
+            href: https://minecraft.wiki/w/Java_Edition_data_values#Blocks
             type: string
             allow: *a-z0-9_#\/:.-
         }
         block: {
             desc: A Minecraft block, vanilla or modded.
-            href: https://minecraft.fandom.com/wiki/Java_Edition_data_values/Blocks
+            href: https://minecraft.wiki/w/Java_Edition_data_values/Blocks
             type: string
             allow: *a-z0-9_#\/:.-
         }

--- a/15/advancements.hjson
+++ b/15/advancements.hjson
@@ -283,7 +283,7 @@
                                             props: {
                                                 potion: {
                                                     desc: A brewed potion ID.
-                                                    href: https://minecraft.fandom.com/wiki/Potion#Item_data
+                                                    href: https://minecraft.wiki/w/Potion#Item_data
                                                     type: string
                                                     allow: *a-z0-9_\/:.-
                                                 }
@@ -456,7 +456,7 @@
                                             props: {
                                                 block: {
                                                     desc: The block that the player is standing in. Accepts block IDs
-                                                    href: https://minecraft.fandom.com/wiki/Java_Edition_data_values/Blocks
+                                                    href: https://minecraft.wiki/w/Java_Edition_data_values/Blocks
                                                     type: string
                                                     allow: *a-z0-9_\/:.-
                                                 }

--- a/15/loot_tables.hjson
+++ b/15/loot_tables.hjson
@@ -49,7 +49,7 @@
                         "string-minecraft:item": {
                             name: {
                                 desc: ID name of the item to be produced, e.g. diamond. The default, if not changed by functions, is a stack of 1 of the default instance of the item.
-                                href: https://minecraft.fandom.com/wiki/Java_Edition_data_values#Blocks
+                                href: https://minecraft.wiki/w/Java_Edition_data_values#Blocks
                                 type: string
                                 allow: *a-z0-9_#\/:.-
                             }

--- a/15/powers.hjson
+++ b/15/powers.hjson
@@ -276,7 +276,7 @@
                                 "string-origins:attribute": {
                                     attribute: {
                                         desc: ID of the attribute of which the value should be checked.
-                                        href: https://minecraft.fandom.com/wiki/Attribute
+                                        href: https://minecraft.wiki/w/Attribute
                                         type: string
                                         allow: *a-z0-9_#\/:.-
                                     }
@@ -292,13 +292,13 @@
                                 "string-origins:biome": {
                                     biome: {
                                         desc: If set, this is the ID of the biome the player needs to be in for this condition to evaluate to true, e.g. minecraft:savanna.
-                                        href: https://minecraft.fandom.com/wiki/Biome#Biome_IDs
+                                        href: https://minecraft.wiki/w/Biome#Biome_IDs
                                         type: string
                                         allow: *a-z0-9_#\/:.-
                                     }
                                     biomes: {
                                         desc: If set, these are the allowed biome IDs the player can be in for this condition to evaluate to true.
-                                        href: https://minecraft.fandom.com/wiki/Biome#Biome_IDs
+                                        href: https://minecraft.wiki/w/Biome#Biome_IDs
                                         type: list
                                         vals: {
                                             type: string
@@ -471,7 +471,7 @@
                                 "string-origins:entity_group": {
                                     group: {
                                         desc: Entity group required for the entity to pass the check. One of default, undead, arthropod, illager, or aquatic. Click for more information about the entity groups.
-                                        href: https://minecraft.fandom.com/wiki/Mob#Classification
+                                        href: https://minecraft.wiki/w/Mob#Classification
                                         enum: ["default", "undead", "arthropod", "illager", "aquatic"]
                                     }
                                 }
@@ -1036,7 +1036,7 @@
                                 "string-origins:harvest_level": {
                                     comparison: {
                                         desc: How the item's harvest level should be compared to the specified value. Click to visit the wiki to learn more about harvest levels.
-                                        href: https://minecraft.fandom.com/wiki/Tiers
+                                        href: https://minecraft.wiki/w/Tiers
                                         link: comparison
                                     }
                                     compare_to: {
@@ -1168,7 +1168,7 @@
                                 "string-origins:block": {
                                     block: {
                                         desc: ID of the block that this block needs to be to pass the check.
-                                        href: https://minecraft.fandom.com/wiki/Java_Edition_data_values/Blocks
+                                        href: https://minecraft.wiki/w/Java_Edition_data_values/Blocks
                                         type: string
                                         allow: *a-z0-9_\/:.-
                                     }
@@ -1569,7 +1569,7 @@
                                 "string-origins:from_falling": {}
                                 "string-origins:in_tag": {
                                     tag: {
-                                        href: https://minecraft.fandom.com/wiki/Tag#Damage_types
+                                        href: https://minecraft.wiki/w/Tag#Damage_types
                                         desc: The namespace and ID of the tag which the damage type should be in to pass the check.
                                         type: string
                                         allow: *a-z0-9_#\/:.-
@@ -2135,7 +2135,7 @@
                                 "string-origins:emit_game_event": {
                                     event: {
                                         desc: The ID of a game event to emit. Click to see vanilla game events.
-                                        href: https://minecraft.fandom.com/wiki/Sculk_Sensor#Vibration_amplitudes
+                                        href: https://minecraft.wiki/w/Sculk_Sensor#Vibration_amplitudes
                                         type: string
                                         allow: *a-z0-9_#\/:.-
                                     }
@@ -2342,7 +2342,7 @@
                                     stat: {
                                         desc: The statistic to modify.
                                         type: string
-                                        href: https://minecraft.fandom.com/wiki/Statistics#Resource_location
+                                        href: https://minecraft.wiki/w/Statistics#Resource_location
                                     }
                                     modifier: {
                                         desc: The modifier to apply to the given stat.
@@ -2553,7 +2553,7 @@
                                 }
                                 "string-origins:selector_action": {
                                     selector: {
-                                        href: https://minecraft.fandom.com/wiki/Target_selectors
+                                        href: https://minecraft.wiki/w/Target_selectors
                                         desc: The selector to use for selecting entities. It can be the username of a player, the UUID of the entity or a target selector.
                                         type: string
                                         ext: true
@@ -3339,7 +3339,7 @@
                         "string-origins:attribute_modify_transfer": {
                             attribute: {
                                 desc: The namespace and ID of the attribute to transfer the value from.
-                                href: https://minecraft.fandom.com/wiki/Attribute
+                                href: https://minecraft.wiki/w/Attribute
                                 type: string
                             }
                             class: {
@@ -3552,7 +3552,7 @@
                         "string-origins:entity_group": {
                             group: {
                                 desc: The group to associate with the player. One of default, undead, arthropod, illager, or aquatic. Click for more information about the entity groups.
-                                href: https://minecraft.fandom.com/wiki/Mob#Classification
+                                href: https://minecraft.wiki/w/Mob#Classification
                                 enum: ["default", "undead", "arthropod", "illager", "aquatic"]
                             }
                         }
@@ -4610,7 +4610,7 @@
                         "string-origins:modify_attribute": {
                             attribute: {
                                 desc: ID of the attribute of which the modifier should be applied.
-                                href: https://minecraft.fandom.com/wiki/Attribute
+                                href: https://minecraft.wiki/w/Attribute
                                 type: string
                                 allow: *a-z0-9_#\/:.-
                             }
@@ -4960,13 +4960,13 @@
                             }
                             biome: {
                                 desc: If set, the player will spawn in the biome with this ID.
-                                href: https://minecraft.fandom.com/wiki/Biome#Biome_IDs
+                                href: https://minecraft.wiki/w/Biome#Biome_IDs
                                 type: string
                                 allow: *a-z0-9_#\/:.-
                             }
                             structure: {
                                 desc: ID of the structure the player should spawn in. Keep in mind that the structure needs to generate in the specified dimension!
-                                href: https://minecraft.fandom.com/wiki/Commands/locate#Arguments
+                                href: https://minecraft.wiki/w/Commands/locate#Arguments
                                 type: string
                                 allow: *a-z0-9_#\/:.-
                             }
@@ -5474,7 +5474,7 @@
             props: {
                 attribute: {
                     desc: ID of the attribute which will be modified by this modifier.
-                    href: https://minecraft.fandom.com/wiki/Attribute
+                    href: https://minecraft.wiki/w/Attribute
                     type: string
                     allow: *a-z0-9_#\/:.-
                 }

--- a/15/predicates.hjson
+++ b/15/predicates.hjson
@@ -38,7 +38,7 @@
             props: {
                 biome: {
                     desc: The biome at the given location.
-                    href: https://minecraft.fandom.com/wiki/Biome#Biome_IDs
+                    href: https://minecraft.wiki/w/Biome#Biome_IDs
                     type: string
                     allow: *a-z0-9#\/:.-
                 }
@@ -47,7 +47,7 @@
                     props: {
                         blocks: {
                             desc: A list of block IDs.
-                            href: https://minecraft.fandom.com/wiki/Java_Edition_data_values/Blocks
+                            href: https://minecraft.wiki/w/Java_Edition_data_values/Blocks
                             type: list
                             vals: {link: "block"}
                         }
@@ -80,7 +80,7 @@
                     props: {
                         blocks: {
                             desc: The fluid ID.
-                            href: https://minecraft.fandom.com/wiki/Java_Edition_data_values#Fluids
+                            href: https://minecraft.wiki/w/Java_Edition_data_values#Fluids
                             type: string
                             allow: *a-z0-9#\/:.-
                         }
@@ -115,7 +115,7 @@
                 }
                 feature: {
                     desc: Whether or not this location is inside a naturally generating structure.
-                    href: https://minecraft.fandom.com/wiki/Commands/locate#Arguments
+                    href: https://minecraft.wiki/w/Commands/locate#Arguments
                     type: string
                 }
                 light: {
@@ -156,7 +156,7 @@
                 }
                 effects: {
                     desc: A list of status effects. The key name is the status effect id.
-                    href: https://minecraft.fandom.com/wiki/Java_Edition_data_values/Effects
+                    href: https://minecraft.wiki/w/Java_Edition_data_values/Effects
                     type: object
                     extra: {
                         type: object
@@ -303,7 +303,7 @@
                 }
                 type: {
                     desc: An entity ID.
-                    href: https://minecraft.fandom.com/wiki/Data_values/Entity_IDs
+                    href: https://minecraft.wiki/w/Data_values/Entity_IDs
                     type: string
                     allow: *a-z0-9_#\/:.-
                 }
@@ -314,7 +314,7 @@
             props: {
                 items: {
                     desc: A list of item IDs.
-                    href: https://minecraft.fandom.com/wiki/Java_Edition_data_values#Blocks
+                    href: https://minecraft.wiki/w/Java_Edition_data_values#Blocks
                     type: list
                     vals: {link: "item"}
                 }
@@ -338,7 +338,7 @@
                 }
                 potion: {
                     desc: A brewed potion ID.
-                    href: https://minecraft.fandom.com/wiki/Potion#Item_data
+                    href: https://minecraft.wiki/w/Potion#Item_data
                     type: string
                     allow: *a-z0-9_#\/:.-
                 }
@@ -350,7 +350,7 @@
                         props: {
                             enchantment: {
                                 desc: An enchantment ID.
-                                href: https://minecraft.fandom.com/wiki/Java_Edition_data_values#Enchantments
+                                href: https://minecraft.wiki/w/Java_Edition_data_values#Enchantments
                                 type: string
                                 allow: *a-z0-9_#\/:.-
                             }
@@ -369,7 +369,7 @@
                         props: {
                             enchantment: {
                                 desc: An enchantment ID.
-                                href: https://minecraft.fandom.com/wiki/Java_Edition_data_values#Enchantments
+                                href: https://minecraft.wiki/w/Java_Edition_data_values#Enchantments
                                 type: string
                                 allow: *a-z0-9_#\/:.-
                             }
@@ -600,13 +600,13 @@
         }
         item: {
             desc: A Minecraft item (or block item), vanilla or modded.
-            href: https://minecraft.fandom.com/wiki/Java_Edition_data_values#Blocks
+            href: https://minecraft.wiki/w/Java_Edition_data_values#Blocks
             type: string
             allow: *a-z0-9_#\/:.-
         }
         block: {
             desc: A Minecraft block, vanilla or modded.
-            href: https://minecraft.fandom.com/wiki/Java_Edition_data_values/Blocks
+            href: https://minecraft.wiki/w/Java_Edition_data_values/Blocks
             type: string
             allow: *a-z0-9_#\/:.-
         }

--- a/6/meta.hjson
+++ b/6/meta.hjson
@@ -31,7 +31,7 @@
                 10: 1.19.0 - 1.19.3
                 12: 1.19.4
                 '''
-            href: https://minecraft.fandom.com/wiki/Pack_format
+            href: https://minecraft.wiki/w/Pack_format
             type: integer
             min: 1
             max: 15

--- a/6/powers.hjson
+++ b/6/powers.hjson
@@ -127,13 +127,13 @@
                                 "string-origins:biome": {
                                     biome: {
                                         desc: If set, this is the ID of the biome the player needs to be in for this condition to evaluate to true, e.g. minecraft:savanna.
-                                        href: https://minecraft.fandom.com/wiki/Biome#Biome_IDs
+                                        href: https://minecraft.wiki/w/Biome#Biome_IDs
                                         type: string
                                         allow: *a-z0-9_#\/:.-
                                     }
                                     biomes: {
                                         desc: If set, these are the allowed biome IDs the player can be in for this condition to evaluate to true.
-                                        href: https://minecraft.fandom.com/wiki/Biome#Biome_IDs
+                                        href: https://minecraft.wiki/w/Biome#Biome_IDs
                                         type: list
                                         vals: {
                                             type: string
@@ -214,7 +214,7 @@
                                     }
                                     permission_level: {
                                         desc: The permission level to use for the command. 0 is a "survival player", anything higher emulates some form of operator. Click for more details.
-                                        href: https://minecraft.fandom.com/wiki/Server.properties#op-permission-level
+                                        href: https://minecraft.wiki/w/Server.properties#op-permission-level
                                         type: integer
                                         default: 4
                                     }
@@ -249,7 +249,7 @@
                                 "string-origins:entity_group": {
                                     group: {
                                         desc: Entity group required for the entity to pass the check. One of default, undead, arthropod, illager, or aquatic. Click for more information about the entity groups.
-                                        href: https://minecraft.fandom.com/wiki/Mob#Classification
+                                        href: https://minecraft.wiki/w/Mob#Classification
                                         enum: ["default", "undead", "arthropod", "illager", "aquatic"]
                                     }
                                 }
@@ -600,7 +600,7 @@
                                 "string-origins:harvest_level": {
                                     comparison: {
                                         desc: How the item's harvest level should be compared to the specified value. Click to visit the wiki to learn more about harvest levels.
-                                        href: https://minecraft.fandom.com/wiki/Tiers
+                                        href: https://minecraft.wiki/w/Tiers
                                         link: comparison
                                     }
                                     compare_to: {
@@ -696,7 +696,7 @@
                                 "string-origins:block": {
                                     block: {
                                         desc: ID of the block that this block needs to be to pass the check.
-                                        href: https://minecraft.fandom.com/wiki/Java_Edition_data_values/Blocks
+                                        href: https://minecraft.wiki/w/Java_Edition_data_values/Blocks
                                         type: string
                                         allow: *a-z0-9_\/:.-
                                     }
@@ -1237,7 +1237,7 @@
                                     }
                                     permission_level: {
                                         desc: The permission level to use for the command. 0 is a "survival player", anything higher emulates some form of operator. Click to see the Minecraft Wiki (op-permission-level) for details.
-                                        href: https://minecraft.fandom.com/wiki/Server.properties#op-permission-level
+                                        href: https://minecraft.wiki/w/Server.properties#op-permission-level
                                         type: integer
                                         default: 4
                                     }
@@ -1575,7 +1575,7 @@
                                     }
                                     permission_level: {
                                         desc: The permission level to use for the command. 0 is a "survival player", anything higher emulates some form of operator. Click to see tje Minecraft Wiki (op-permission-level) for details.
-                                        href: https://minecraft.fandom.com/wiki/Server.properties#op-permission-level
+                                        href: https://minecraft.wiki/w/Server.properties#op-permission-level
                                         type: integer
                                         default: 4
                                     }
@@ -1876,7 +1876,7 @@
                         "string-origins:entity_group": {
                             group: {
                                 desc: The group to associate with the player. One of default, undead, arthropod, illager, or aquatic. Click for more information about the entity groups.
-                                href: https://minecraft.fandom.com/wiki/Mob#Classification
+                                href: https://minecraft.wiki/w/Mob#Classification
                                 enum: ["default", "undead", "arthropod", "illager", "aquatic"]
                             }
                         }
@@ -2584,13 +2584,13 @@
                             }
                             biome: {
                                 desc: If set, the player will spawn in the biome with this ID.
-                                href: https://minecraft.fandom.com/wiki/Biome#Biome_IDs
+                                href: https://minecraft.wiki/w/Biome#Biome_IDs
                                 type: string
                                 allow: *a-z0-9_#\/:.-
                             }
                             structure: {
                                 desc: ID of the structure the player should spawn in. Keep in mind that the structure needs to generate in the specified dimension!
-                                href: https://minecraft.fandom.com/wiki/Commands/locate#Arguments
+                                href: https://minecraft.wiki/w/Commands/locate#Arguments
                                 type: string
                                 allow: *a-z0-9_#\/:.-
                             }
@@ -3016,7 +3016,7 @@
         }
         item: {
             desc: A Minecraft item (or block item), vanilla or modded.
-            href: https://minecraft.fandom.com/wiki/Java_Edition_data_values#Blocks
+            href: https://minecraft.wiki/w/Java_Edition_data_values#Blocks
             type: string
             allow: *a-z0-9_#\/:.-
         }

--- a/6/recipes.hjson
+++ b/6/recipes.hjson
@@ -2,7 +2,7 @@
     links: {
         item: {
             desc: A Minecraft item (or block item), vanilla or modded.
-            href: https://minecraft.fandom.com/wiki/Java_Edition_data_values#Blocks
+            href: https://minecraft.wiki/w/Java_Edition_data_values#Blocks
             type: string
             allow: *a-z0-9_:-
         }
@@ -152,7 +152,7 @@
                         result: {extend: "item", gap: true}
                         experience: {
                             desc: The output experience of the recipe. Click the link to see default smelting experience points.
-                            href: https://minecraft.fandom.com/wiki/Smelting#Recipes
+                            href: https://minecraft.wiki/w/Smelting#Recipes
                             type: number
                             min: 0
                             default: 0

--- a/7/advancements.hjson
+++ b/7/advancements.hjson
@@ -206,7 +206,7 @@
                                     props: {
                                         potion: {
                                             desc: A brewed potion ID.
-                                            href: https://minecraft.fandom.com/wiki/Potion#Item_data
+                                            href: https://minecraft.wiki/w/Potion#Item_data
                                             type: string
                                             allow: *a-z0-9_\/:.-
                                         }
@@ -379,7 +379,7 @@
                                     props: {
                                         block: {
                                             desc: The block that the player is standing in. Accepts block IDs
-                                            href: https://minecraft.fandom.com/wiki/Java_Edition_data_values/Blocks
+                                            href: https://minecraft.wiki/w/Java_Edition_data_values/Blocks
                                             type: string
                                             allow: *a-z0-9_\/:.-
                                         }

--- a/7/item_modifiers.hjson
+++ b/7/item_modifiers.hjson
@@ -100,7 +100,7 @@
                                         props: {
                                             id: {
                                                 desc: The namespaced item ID.
-                                                href: https://minecraft.fandom.com/wiki/Java_Edition_data_values#Blocks
+                                                href: https://minecraft.wiki/w/Java_Edition_data_values#Blocks
                                                 type: string
                                                 allow: *a-z0-9_#\/:.-
                                             }
@@ -133,7 +133,7 @@
                                             }
                                             type: {
                                                 desc: A string containing the type of the entity. Should be a namespaced entity ID. Present minecraft:pig if invalid.
-                                                href: https://minecraft.fandom.com/wiki/Java_Edition_data_values/Entities
+                                                href: https://minecraft.wiki/w/Java_Edition_data_values/Entities
                                                 type: string
                                                 allow: *a-z0-9_#\/:.-
                                             }
@@ -203,7 +203,7 @@
                 {title: "key", type: "object", extend: "jsontxtbase", props: {
                     keybind: {
                         desc: A keybind identifier, to be displayed as the name of the button that is currently bound to that action. For example, {"keybind": "key.inventory"} displays "e" if the player is using the default control scheme.
-                        href: https://minecraft.fandom.com/wiki/Controls#Configurable_controls
+                        href: https://minecraft.wiki/w/Controls#Configurable_controls
                         type: string
                     }
                 }}
@@ -283,7 +283,7 @@
                         "string-minecraft:apply_bonus": {
                             enchantment: {
                                 desc: Enchantment ID used for level calculation.
-                                href: https://minecraft.fandom.com/wiki/Java_Edition_data_value#Enchantments
+                                href: https://minecraft.wiki/w/Java_Edition_data_value#Enchantments
                                 type: string
                                 allow: *a-z0-9_#\/:.-
                             }
@@ -366,7 +366,7 @@
                         "string-minecraft:copy_state": {
                             block: {
                                 desc: A block ID. Function fails if the block doesn't match.
-                                href: https://minecraft.fandom.com/wiki/Resource_location
+                                href: https://minecraft.wiki/w/Resource_location
                                 type: string
                             }
                             properties: {
@@ -378,7 +378,7 @@
                         "string-minecraft:enchant_randomly": {
                             enchantments: {
                                 desc: A list of enchantment IDs to choose from to enchant the item with. Only one will be selected, just with a random level. If omitted, all enchantments applicable to the item are possible.
-                                href: https://minecraft.fandom.com/wiki/Java_Edition_data_value#Enchantments
+                                href: https://minecraft.wiki/w/Java_Edition_data_value#Enchantments
                                 type: list
                                 vals: {type: "string"}
                             }
@@ -390,13 +390,13 @@
                         "string-minecraft:exploration_map": {
                             destination: {
                                 desc: The type of generated structure to convert this empty map to lead to. Accepts any structure id used by the /locate command.
-                                href: https://minecraft.fandom.com/wiki/Commands/locate#Arguments
+                                href: https://minecraft.wiki/w/Commands/locate#Arguments
                                 type: string
                                 allow: *a-z0-9_#\/:.-
                             }
                             decoration: {
                                 desc: The icon used to mark the destination on the map. Accepts any of the map icon text IDs (case insensitive). If mansion or monument is used, the color of the lines on the item texture changes to match the corresponding explorer map.
-                                href: https://minecraft.fandom.com/wiki/Map#Map_icons
+                                href: https://minecraft.wiki/w/Map#Map_icons
                                 type: string
                                 allow: *a-z0-9_#\/:.-
                             }
@@ -491,7 +491,7 @@
                                     props: {
                                         pattern: {
                                             desc: The pattern type. For example square_bottom_left.
-                                            href: https://minecraft.fandom.com/wiki/Banner/Patterns
+                                            href: https://minecraft.wiki/w/Banner/Patterns
                                             type: string
                                             allow: *a-z0-9_#\/:.-
                                         }
@@ -606,7 +606,7 @@
                         "string-minecraft:set_potion": {
                             id: {
                                 desc: The potion ID.
-                                href: https://minecraft.fandom.com/wiki/Potion#Java_Edition
+                                href: https://minecraft.wiki/w/Potion#Java_Edition
                                 type: string
                                 allow: *a-z0-9_#\/:.-
                             }
@@ -620,7 +620,7 @@
                                     props: {
                                         type: {
                                             desc: The effect ID.
-                                            href: https://minecraft.fandom.com/wiki/Effect#Effect_list
+                                            href: https://minecraft.wiki/w/Effect#Effect_list
                                             type: string
                                             allow: *a-z0-9_#\/:.-
                                         }

--- a/7/loot_tables.hjson
+++ b/7/loot_tables.hjson
@@ -49,7 +49,7 @@
                         "string-minecraft:item": {
                             name: {
                                 desc: ID name of the item to be produced, e.g. diamond. The default, if not changed by functions, is a stack of 1 of the default instance of the item.
-                                href: https://minecraft.fandom.com/wiki/Java_Edition_data_values#Blocks
+                                href: https://minecraft.wiki/w/Java_Edition_data_values#Blocks
                                 type: string
                                 allow: *a-z0-9_#\/:.-
                             }

--- a/7/powers.hjson
+++ b/7/powers.hjson
@@ -250,13 +250,13 @@
                                 "string-origins:biome": {
                                     biome: {
                                         desc: If set, this is the ID of the biome the player needs to be in for this condition to evaluate to true, e.g. minecraft:savanna.
-                                        href: https://minecraft.fandom.com/wiki/Biome#Biome_IDs
+                                        href: https://minecraft.wiki/w/Biome#Biome_IDs
                                         type: string
                                         allow: *a-z0-9_#\/:.-
                                     }
                                     biomes: {
                                         desc: If set, these are the allowed biome IDs the player can be in for this condition to evaluate to true.
-                                        href: https://minecraft.fandom.com/wiki/Biome#Biome_IDs
+                                        href: https://minecraft.wiki/w/Biome#Biome_IDs
                                         type: list
                                         vals: {
                                             type: string
@@ -367,7 +367,7 @@
                                 "string-origins:entity_group": {
                                     group: {
                                         desc: Entity group required for the entity to pass the check. One of default, undead, arthropod, illager, or aquatic. Click for more information about the entity groups.
-                                        href: https://minecraft.fandom.com/wiki/Mob#Classification
+                                        href: https://minecraft.wiki/w/Mob#Classification
                                         enum: ["default", "undead", "arthropod", "illager", "aquatic"]
                                     }
                                 }
@@ -800,7 +800,7 @@
                                 "string-origins:harvest_level": {
                                     comparison: {
                                         desc: How the item's harvest level should be compared to the specified value. Click to visit the wiki to learn more about harvest levels.
-                                        href: https://minecraft.fandom.com/wiki/Tiers
+                                        href: https://minecraft.wiki/w/Tiers
                                         link: comparison
                                     }
                                     compare_to: {
@@ -904,7 +904,7 @@
                                 "string-origins:block": {
                                     block: {
                                         desc: ID of the block that this block needs to be to pass the check.
-                                        href: https://minecraft.fandom.com/wiki/Java_Edition_data_values/Blocks
+                                        href: https://minecraft.wiki/w/Java_Edition_data_values/Blocks
                                         type: string
                                         allow: *a-z0-9_\/:.-
                                     }
@@ -1568,7 +1568,7 @@
                                 "string-origins:emit_game_event": {
                                     event: {
                                         desc: The ID of a game event to emit. Click to see vanilla game events.
-                                        href: https://minecraft.fandom.com/wiki/Sculk_Sensor#Vibration_amplitudes
+                                        href: https://minecraft.wiki/w/Sculk_Sensor#Vibration_amplitudes
                                         type: string
                                         allow: *a-z0-9_#\/:.-
                                     }
@@ -2444,7 +2444,7 @@
                         "string-origins:entity_group": {
                             group: {
                                 desc: The group to associate with the player. One of default, undead, arthropod, illager, or aquatic. Click for more information about the entity groups.
-                                href: https://minecraft.fandom.com/wiki/Mob#Classification
+                                href: https://minecraft.wiki/w/Mob#Classification
                                 enum: ["default", "undead", "arthropod", "illager", "aquatic"]
                             }
                         }
@@ -3529,13 +3529,13 @@
                             }
                             biome: {
                                 desc: If set, the player will spawn in the biome with this ID.
-                                href: https://minecraft.fandom.com/wiki/Biome#Biome_IDs
+                                href: https://minecraft.wiki/w/Biome#Biome_IDs
                                 type: string
                                 allow: *a-z0-9_#\/:.-
                             }
                             structure: {
                                 desc: ID of the structure the player should spawn in. Keep in mind that the structure needs to generate in the specified dimension!
-                                href: https://minecraft.fandom.com/wiki/Commands/locate#Arguments
+                                href: https://minecraft.wiki/w/Commands/locate#Arguments
                                 type: string
                                 allow: *a-z0-9_#\/:.-
                             }

--- a/7/predicates.hjson
+++ b/7/predicates.hjson
@@ -60,7 +60,7 @@
             props: {
                 biome: {
                     desc: The biome at the given location.
-                    href: https://minecraft.fandom.com/wiki/Biome#Biome_IDs
+                    href: https://minecraft.wiki/w/Biome#Biome_IDs
                     type: string
                     allow: *a-z0-9#\/:.-
                 }
@@ -69,7 +69,7 @@
                     props: {
                         blocks: {
                             desc: A list of block IDs.
-                            href: https://minecraft.fandom.com/wiki/Java_Edition_data_values/Blocks
+                            href: https://minecraft.wiki/w/Java_Edition_data_values/Blocks
                             type: list
                             vals: {link: "block"}
                         }
@@ -102,7 +102,7 @@
                     props: {
                         blocks: {
                             desc: The fluid ID.
-                            href: https://minecraft.fandom.com/wiki/Java_Edition_data_values#Fluids
+                            href: https://minecraft.wiki/w/Java_Edition_data_values#Fluids
                             type: string
                             allow: *a-z0-9#\/:.-
                         }
@@ -137,7 +137,7 @@
                 }
                 feature: {
                     desc: Whether or not this location is inside a naturally generating structure.
-                    href: https://minecraft.fandom.com/wiki/Commands/locate#Arguments
+                    href: https://minecraft.wiki/w/Commands/locate#Arguments
                     type: string
                 }
                 light: {
@@ -178,7 +178,7 @@
                 }
                 effects: {
                     desc: A list of status effects. The key name is the status effect id.
-                    href: https://minecraft.fandom.com/wiki/Java_Edition_data_values/Effects
+                    href: https://minecraft.wiki/w/Java_Edition_data_values/Effects
                     type: object
                     extra: {
                         type: object
@@ -325,7 +325,7 @@
                 }
                 type: {
                     desc: An entity ID.
-                    href: https://minecraft.fandom.com/wiki/Data_values/Entity_IDs
+                    href: https://minecraft.wiki/w/Data_values/Entity_IDs
                     type: string
                     allow: *a-z0-9_#\/:.-
                 }
@@ -336,7 +336,7 @@
             props: {
                 items: {
                     desc: A list of item IDs.
-                    href: https://minecraft.fandom.com/wiki/Java_Edition_data_values#Blocks
+                    href: https://minecraft.wiki/w/Java_Edition_data_values#Blocks
                     type: list
                     vals: {link: "item"}
                 }
@@ -360,7 +360,7 @@
                 }
                 potion: {
                     desc: A brewed potion ID.
-                    href: https://minecraft.fandom.com/wiki/Potion#Item_data
+                    href: https://minecraft.wiki/w/Potion#Item_data
                     type: string
                     allow: *a-z0-9_#\/:.-
                 }
@@ -372,7 +372,7 @@
                         props: {
                             enchantment: {
                                 desc: An enchantment ID.
-                                href: https://minecraft.fandom.com/wiki/Java_Edition_data_values#Enchantments
+                                href: https://minecraft.wiki/w/Java_Edition_data_values#Enchantments
                                 type: string
                                 allow: *a-z0-9_#\/:.-
                             }
@@ -391,7 +391,7 @@
                         props: {
                             enchantment: {
                                 desc: An enchantment ID.
-                                href: https://minecraft.fandom.com/wiki/Java_Edition_data_values#Enchantments
+                                href: https://minecraft.wiki/w/Java_Edition_data_values#Enchantments
                                 type: string
                                 allow: *a-z0-9_#\/:.-
                             }
@@ -622,13 +622,13 @@
         }
         item: {
             desc: A Minecraft item (or block item), vanilla or modded.
-            href: https://minecraft.fandom.com/wiki/Java_Edition_data_values#Blocks
+            href: https://minecraft.wiki/w/Java_Edition_data_values#Blocks
             type: string
             allow: *a-z0-9_#\/:.-
         }
         block: {
             desc: A Minecraft block, vanilla or modded.
-            href: https://minecraft.fandom.com/wiki/Java_Edition_data_values/Blocks
+            href: https://minecraft.wiki/w/Java_Edition_data_values/Blocks
             type: string
             allow: *a-z0-9_#\/:.-
         }

--- a/8/advancements.hjson
+++ b/8/advancements.hjson
@@ -209,7 +209,7 @@
                                     props: {
                                         potion: {
                                             desc: A brewed potion ID.
-                                            href: https://minecraft.fandom.com/wiki/Potion#Item_data
+                                            href: https://minecraft.wiki/w/Potion#Item_data
                                             type: string
                                             allow: *a-z0-9_\/:.-
                                         }
@@ -382,7 +382,7 @@
                                     props: {
                                         block: {
                                             desc: The block that the player is standing in. Accepts block IDs
-                                            href: https://minecraft.fandom.com/wiki/Java_Edition_data_values/Blocks
+                                            href: https://minecraft.wiki/w/Java_Edition_data_values/Blocks
                                             type: string
                                             allow: *a-z0-9_\/:.-
                                         }

--- a/8/loot_tables.hjson
+++ b/8/loot_tables.hjson
@@ -49,7 +49,7 @@
                         "string-minecraft:item": {
                             name: {
                                 desc: ID name of the item to be produced, e.g. diamond. The default, if not changed by functions, is a stack of 1 of the default instance of the item.
-                                href: https://minecraft.fandom.com/wiki/Java_Edition_data_values#Blocks
+                                href: https://minecraft.wiki/w/Java_Edition_data_values#Blocks
                                 type: string
                                 allow: *a-z0-9_#\/:.-
                             }

--- a/8/powers.hjson
+++ b/8/powers.hjson
@@ -289,13 +289,13 @@
                                 "string-origins:biome": {
                                     biome: {
                                         desc: If set, this is the ID of the biome the player needs to be in for this condition to evaluate to true, e.g. minecraft:savanna.
-                                        href: https://minecraft.fandom.com/wiki/Biome#Biome_IDs
+                                        href: https://minecraft.wiki/w/Biome#Biome_IDs
                                         type: string
                                         allow: *a-z0-9_#\/:.-
                                     }
                                     biomes: {
                                         desc: If set, these are the allowed biome IDs the player can be in for this condition to evaluate to true.
-                                        href: https://minecraft.fandom.com/wiki/Biome#Biome_IDs
+                                        href: https://minecraft.wiki/w/Biome#Biome_IDs
                                         type: list
                                         vals: {
                                             type: string
@@ -464,7 +464,7 @@
                                 "string-origins:entity_group": {
                                     group: {
                                         desc: Entity group required for the entity to pass the check. One of default, undead, arthropod, illager, or aquatic. Click for more information about the entity groups.
-                                        href: https://minecraft.fandom.com/wiki/Mob#Classification
+                                        href: https://minecraft.wiki/w/Mob#Classification
                                         enum: ["default", "undead", "arthropod", "illager", "aquatic"]
                                     }
                                 }
@@ -972,7 +972,7 @@
                                 "string-origins:harvest_level": {
                                     comparison: {
                                         desc: How the item's harvest level should be compared to the specified value. Click to visit the wiki to learn more about harvest levels.
-                                        href: https://minecraft.fandom.com/wiki/Tiers
+                                        href: https://minecraft.wiki/w/Tiers
                                         link: comparison
                                     }
                                     compare_to: {
@@ -1092,7 +1092,7 @@
                                 "string-origins:block": {
                                     block: {
                                         desc: ID of the block that this block needs to be to pass the check.
-                                        href: https://minecraft.fandom.com/wiki/Java_Edition_data_values/Blocks
+                                        href: https://minecraft.wiki/w/Java_Edition_data_values/Blocks
                                         type: string
                                         allow: *a-z0-9_\/:.-
                                     }
@@ -1951,7 +1951,7 @@
                                 "string-origins:emit_game_event": {
                                     event: {
                                         desc: The ID of a game event to emit. Click to see vanilla game events.
-                                        href: https://minecraft.fandom.com/wiki/Sculk_Sensor#Vibration_amplitudes
+                                        href: https://minecraft.wiki/w/Sculk_Sensor#Vibration_amplitudes
                                         type: string
                                         allow: *a-z0-9_#\/:.-
                                     }
@@ -3057,7 +3057,7 @@
                         "string-origins:entity_group": {
                             group: {
                                 desc: The group to associate with the player. One of default, undead, arthropod, illager, or aquatic. Click for more information about the entity groups.
-                                href: https://minecraft.fandom.com/wiki/Mob#Classification
+                                href: https://minecraft.wiki/w/Mob#Classification
                                 enum: ["default", "undead", "arthropod", "illager", "aquatic"]
                             }
                         }
@@ -4242,13 +4242,13 @@
                             }
                             biome: {
                                 desc: If set, the player will spawn in the biome with this ID.
-                                href: https://minecraft.fandom.com/wiki/Biome#Biome_IDs
+                                href: https://minecraft.wiki/w/Biome#Biome_IDs
                                 type: string
                                 allow: *a-z0-9_#\/:.-
                             }
                             structure: {
                                 desc: ID of the structure the player should spawn in. Keep in mind that the structure needs to generate in the specified dimension!
-                                href: https://minecraft.fandom.com/wiki/Commands/locate#Arguments
+                                href: https://minecraft.wiki/w/Commands/locate#Arguments
                                 type: string
                                 allow: *a-z0-9_#\/:.-
                             }

--- a/8/predicates.hjson
+++ b/8/predicates.hjson
@@ -60,7 +60,7 @@
             props: {
                 biome: {
                     desc: The biome at the given location.
-                    href: https://minecraft.fandom.com/wiki/Biome#Biome_IDs
+                    href: https://minecraft.wiki/w/Biome#Biome_IDs
                     type: string
                     allow: *a-z0-9#\/:.-
                 }
@@ -69,7 +69,7 @@
                     props: {
                         blocks: {
                             desc: A list of block IDs.
-                            href: https://minecraft.fandom.com/wiki/Java_Edition_data_values/Blocks
+                            href: https://minecraft.wiki/w/Java_Edition_data_values/Blocks
                             type: list
                             vals: {link: "block"}
                         }
@@ -102,7 +102,7 @@
                     props: {
                         blocks: {
                             desc: The fluid ID.
-                            href: https://minecraft.fandom.com/wiki/Java_Edition_data_values#Fluids
+                            href: https://minecraft.wiki/w/Java_Edition_data_values#Fluids
                             type: string
                             allow: *a-z0-9#\/:.-
                         }
@@ -137,7 +137,7 @@
                 }
                 feature: {
                     desc: Whether or not this location is inside a naturally generating structure.
-                    href: https://minecraft.fandom.com/wiki/Commands/locate#Arguments
+                    href: https://minecraft.wiki/w/Commands/locate#Arguments
                     type: string
                 }
                 light: {
@@ -178,7 +178,7 @@
                 }
                 effects: {
                     desc: A list of status effects. The key name is the status effect id.
-                    href: https://minecraft.fandom.com/wiki/Java_Edition_data_values/Effects
+                    href: https://minecraft.wiki/w/Java_Edition_data_values/Effects
                     type: object
                     extra: {
                         type: object
@@ -325,7 +325,7 @@
                 }
                 type: {
                     desc: An entity ID.
-                    href: https://minecraft.fandom.com/wiki/Data_values/Entity_IDs
+                    href: https://minecraft.wiki/w/Data_values/Entity_IDs
                     type: string
                     allow: *a-z0-9_#\/:.-
                 }
@@ -336,7 +336,7 @@
             props: {
                 items: {
                     desc: A list of item IDs.
-                    href: https://minecraft.fandom.com/wiki/Java_Edition_data_values#Blocks
+                    href: https://minecraft.wiki/w/Java_Edition_data_values#Blocks
                     type: list
                     vals: {link: "item"}
                 }
@@ -360,7 +360,7 @@
                 }
                 potion: {
                     desc: A brewed potion ID.
-                    href: https://minecraft.fandom.com/wiki/Potion#Item_data
+                    href: https://minecraft.wiki/w/Potion#Item_data
                     type: string
                     allow: *a-z0-9_#\/:.-
                 }
@@ -372,7 +372,7 @@
                         props: {
                             enchantment: {
                                 desc: An enchantment ID.
-                                href: https://minecraft.fandom.com/wiki/Java_Edition_data_values#Enchantments
+                                href: https://minecraft.wiki/w/Java_Edition_data_values#Enchantments
                                 type: string
                                 allow: *a-z0-9_#\/:.-
                             }
@@ -391,7 +391,7 @@
                         props: {
                             enchantment: {
                                 desc: An enchantment ID.
-                                href: https://minecraft.fandom.com/wiki/Java_Edition_data_values#Enchantments
+                                href: https://minecraft.wiki/w/Java_Edition_data_values#Enchantments
                                 type: string
                                 allow: *a-z0-9_#\/:.-
                             }
@@ -622,13 +622,13 @@
         }
         item: {
             desc: A Minecraft item (or block item), vanilla or modded.
-            href: https://minecraft.fandom.com/wiki/Java_Edition_data_values#Blocks
+            href: https://minecraft.wiki/w/Java_Edition_data_values#Blocks
             type: string
             allow: *a-z0-9_#\/:.-
         }
         block: {
             desc: A Minecraft block, vanilla or modded.
-            href: https://minecraft.fandom.com/wiki/Java_Edition_data_values/Blocks
+            href: https://minecraft.wiki/w/Java_Edition_data_values/Blocks
             type: string
             allow: *a-z0-9_#\/:.-
         }


### PR DESCRIPTION
The Minecraft Fandom wiki has been forked to a new domain: minecraft.wiki. Learn more here: https://minecraft.wiki/w/Minecraft_Wiki:Moving_from_Fandom. This PR updates all URLs accordingly.